### PR TITLE
Add Apple Silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ This repository contains code from our 2022 CVPR paper [**AEGNN: Asynchronous Ev
 ```
 
 ## Installation
-The code heavily depends on PyTorch and the [PyG](https://github.com/pyg-team/pytorch_geometric) framework, which is 
+The code heavily depends on PyTorch and the [PyG](https://github.com/pyg-team/pytorch_geometric) framework, which is
 optimized only for GPUs supporting CUDA. For our implementation the CUDA version 11.3 is used. Install the project
 requirements with:
 ```
 conda env create --file=environment.yml
+```
+
+If you want to run the code on Apple&nbsp;Silicon (M1/M2) without CUDA support,
+use the provided conda environment for macOS:
+
+```
+conda env create --file=environment_macos_arm64.yml
 ```
 
 ## Processing Pipeline

--- a/aegnn/datasets/gen1.py
+++ b/aegnn/datasets/gen1.py
@@ -5,6 +5,7 @@ import numpy as np
 import pickle
 import sys
 import torch
+import aegnn
 
 from torch_geometric.data import Data
 from torch_geometric.nn.pool import radius_graph
@@ -83,7 +84,7 @@ class Gen1(EventDataModule):
             sample_dict['sample_idx'] = sample_idx
 
             # Graph generation (edges w.r.t. sub-sampled graph).
-            device = torch.device(torch.cuda.current_device())
+            device = aegnn.utils.default_device()
             sample.pos[:, 2] = normalize_time(sample.pos[:, 2])
             edge_index = radius_graph(sample.pos.to(device), r=params["r"], max_num_neighbors=params["d_max"])
             sample_dict['edge_index'] = edge_index.cpu()

--- a/aegnn/datasets/ncaltech101.py
+++ b/aegnn/datasets/ncaltech101.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import os
 import torch
+import aegnn
 
 from torch_geometric.data import Data
 from torch_geometric.nn.pool import radius_graph
@@ -72,7 +73,8 @@ class NCaltech101(EventDataModule):
         all_p = all_p.astype(np.float64)
         all_p[all_p == 0] = -1
         events = np.column_stack((all_x, all_y, all_ts, all_p))
-        events = torch.from_numpy(events).float().cuda()
+        device = aegnn.utils.default_device()
+        events = torch.from_numpy(events).float().to(device)
 
         x, pos = events[:, -1:], events[:, :3]   # x = polarity, pos = spatio-temporal position
         return Data(x=x, pos=pos)
@@ -114,7 +116,7 @@ class NCaltech101(EventDataModule):
         rf_wo_ext, _ = os.path.splitext(rf)
 
         # Load data from raw file. If the according loaders are available, add annotation, label and class id.
-        device = "cpu"  # torch.device(torch.cuda.current_device())
+        device = aegnn.utils.default_device()
         data_obj = load_func(rf).to(device)
         data_obj.file_id = os.path.basename(rf)
         if (label := read_label(rf)) is not None:

--- a/aegnn/datasets/ncars.py
+++ b/aegnn/datasets/ncars.py
@@ -2,6 +2,7 @@ import glob
 import numpy as np
 import os
 import torch
+import aegnn
 
 from torch_geometric.data import Data
 from torch_geometric.nn.pool import radius_graph
@@ -33,7 +34,8 @@ class NCars(NCaltech101):
     @staticmethod
     def load(raw_file: str) -> Data:
         events_file = os.path.join(raw_file, "events.txt")
-        events = torch.from_numpy(np.loadtxt(events_file)).float().cuda()
+        device = aegnn.utils.default_device()
+        events = torch.from_numpy(np.loadtxt(events_file)).float().to(device)
         x, pos = events[:, -1:], events[:, :3]
         return Data(x=x, pos=pos)
 

--- a/aegnn/utils/__init__.py
+++ b/aegnn/utils/__init__.py
@@ -4,3 +4,18 @@ from aegnn.utils.multiprocessing import TaskManager
 
 import aegnn.utils.callbacks
 import aegnn.utils.loggers
+
+import torch
+
+
+def default_device() -> torch.device:
+    """Return the best available torch device.
+
+    The function prefers CUDA if available, then falls back to the MPS backend
+    on Apple silicon and finally to the CPU.
+    """
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")

--- a/environment_macos_arm64.yml
+++ b/environment_macos_arm64.yml
@@ -1,0 +1,22 @@
+name: aegnn_macos
+channels:
+  - pyg
+  - pytorch
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - numpy
+  - pandas
+  - scikit-learn
+  - scipy
+  - matplotlib
+  - pytorch=1.12.1
+  - torchvision
+  - torchaudio
+  - pyg
+  - pip
+  - pip:
+      - pytorch-lightning==1.4.9
+      - tensorboard
+      - wandb

--- a/evaluation/flops.py
+++ b/evaluation/flops.py
@@ -111,7 +111,8 @@ def run_experiments(dm, args, experiments: List[int], num_trials: int, device: t
 
         # Fully reset run to ensure independence between subsequent experiments.
         del model  # fully delete model
-        torch.cuda.empty_cache()  # clear memory
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()  # clear memory
 
     print(f"Results are logged in {output_file}")
     return results_df


### PR DESCRIPTION
## Summary
- add `default_device` helper for choosing CUDA/MPS/CPU
- use default device in dataset loading code
- create `environment_macos_arm64.yml` for Apple Silicon
- document macOS installation instructions
- guard CUDA cache clearing in FLOPs evaluation

## Testing
- `pytest -q`
- `python -m py_compile aegnn/utils/__init__.py aegnn/datasets/ncars.py aegnn/datasets/ncaltech101.py aegnn/datasets/gen1.py evaluation/flops.py`


------
https://chatgpt.com/codex/tasks/task_e_684e3141c6f88323b94977ee4ab6a895